### PR TITLE
Fix a typo in a next_step link

### DIFF
--- a/sites/es/frontend/herramientas_de_desarrollo.step
+++ b/sites/es/frontend/herramientas_de_desarrollo.step
@@ -64,4 +64,4 @@ Con las herramientas de desarrollo adecuadas, puedes inspeccionar cada sitio que
   MARKDOWN
 end
 
-next_step "agrega_archivos_iniciales"
+next_step "agregar_archivos_iniciales"


### PR DESCRIPTION
Right now, there's a typo in a `next_step` link near the end of the frontend curriculum: The link is to `agrega_archivos_iniciales` but the page is `agregar_archivos_iniciales`. I fixed that link.

I thought there would be a separate spot to fix the left navigation bar, but it looks like that's automatically generated; changing the `next_step` link also changed the nav! :tada: 

![screen shot 2015-06-17 at 9 44 17 am](https://cloud.githubusercontent.com/assets/209641/8213346/19fef0ca-14d6-11e5-892b-3d4fe9f9a85b.png)

Thanks for reviewing this!

Let me know if there's anything else I should do for this PR. :bow:
